### PR TITLE
fix🐛: 修复了图片发送

### DIFF
--- a/apps/help.js
+++ b/apps/help.js
@@ -73,7 +73,7 @@ export class Help extends plugin {
 
             // 发送图片
             try {
-                await e.reply(segment.image(`file:///${screenshotPath}`));
+                await e.reply(segment.image(`${screenshotPath}`));
             } finally {
                 // 删除临时文件
                 if (fs.existsSync(screenshotPath)) {
@@ -131,7 +131,7 @@ export class Help extends plugin {
 
             // 发送图片
             try {
-                await e.reply(segment.image(`file:///${screenshotPath}`));
+                await e.reply(segment.image(`${screenshotPath}`));
             } finally {
                 // 删除临时文件
                 if (fs.existsSync(screenshotPath)) {

--- a/apps/mc-user.js
+++ b/apps/mc-user.js
@@ -1018,7 +1018,7 @@ export class MCUser extends plugin {
 
             // 发送图片
             try {
-                await e.reply(segment.image(`file:///${screenshotPath}`));
+                await e.reply(segment.image(`${screenshotPath}`));
                 return true;
             } finally {
                 // 删除临时文件
@@ -1584,25 +1584,13 @@ export class MCUser extends plugin {
                         throw new Error(result.message || '生成失败');
                     }
 
-                    // 将Base64转换为图片
+                    // 直接发送Base64数据
                     const base64Data = result.data.image;
-                    const imageData = Buffer.from(base64Data, 'base64');
-                    const tempDir = path.join(process.cwd(), 'plugins', 'mctool-plugin', 'temp');
-                    if (!fs.existsSync(tempDir)) {
-                        fs.mkdirSync(tempDir, { recursive: true });
-                    }
-
-                    const tempFile = path.join(tempDir, `${user.username}_${type}_${Date.now()}.png`);
-                    fs.writeFileSync(tempFile, imageData);
-
-                    // 直接发送消息
                     await e.reply([
                         `${user.username} (${user.platform === 'littleskin' ? 'LittleSkin' : 'Mojang'}) 的${type}图像：\n`,
-                        segment.image(`file:///${tempFile}`)
+                        segment.image(`base64://${base64Data}`)
                     ]);
 
-                    // 删除临时文件
-                    fs.unlinkSync(tempFile);
                 } catch (error) {
                     logger.error(`[MCTool] 生成 ${user.username} 的头像失败:`, error);
                     await e.reply(`生成 ${user.username} (${user.platform === 'littleskin' ? 'LittleSkin' : 'Mojang'}) 的头像失败: ${error.message}`);


### PR DESCRIPTION
修复图片发送，头像改为直接发送base64而不转成图片再转base64发送💦


测试平台：
napcat 4.4.10 
trss 3.1.3 
分别以 linux 下以文件地址发送 和 win 下以 base64 发送